### PR TITLE
Vizualizer zoom, Sidebar Back, and Upload page updates

### DIFF
--- a/notes.js
+++ b/notes.js
@@ -68,9 +68,12 @@ const links = {
   AWS: `https://aws.amazon.com/kubernetes/`, // or https://aws.amazon.com/eks/
   dockerGraphQL: `https://medium.com/maxime-heckel/building-a-graphql-wrapper-for-the-docker-api-2109f2b9c202`,
   dockerDocs: `https://docs.docker.com/engine/api/v1.40/#`,
-  GoogleCloid: `https://console.cloud.google.com/home/dashboard?folder=&organizationId=&project=lexical-period-255501`
-<<<<<<< HEAD
+  GoogleCloid: `https://console.cloud.google.com/home/dashboard?folder=&organizationId=&project=lexical-period-255501`,
+
+  Jimmy: {
+    deployment,
+    ingress,
+    service,
+    video: 'https://youtu.be/SC7lLm6QAb8',
+  }
 }
-=======
-}
->>>>>>> fc0a574617292e3697bef98211a06a1e0fe1316b

--- a/src/client/components/UploadPage.tsx
+++ b/src/client/components/UploadPage.tsx
@@ -58,7 +58,7 @@ const UploadPage = () => {
               <div className='kubUploadText'>Google Cloud Platform</div>
             </div>
 
-        <input id="uploadEnterClustInfo" className='uploadInput' type="text" onChange={handleInput} placeholder="Enter Cluster Info"/>
+        <input id="uploadEnterClustInfo" className='uploadInput' type="text" onChange={handleInput} placeholder="Enter Project Info"/>
         <div id="uploadDivForSubmitandBackButts">
         <button id="uploadSubmit" className='uploadButt' onClick={handleSubmit}> Submit </button>
         &nbsp;

--- a/src/client/components/sidebar.tsx
+++ b/src/client/components/sidebar.tsx
@@ -8,8 +8,17 @@ const SideBar = () =>{
         setStore({...Store, gcpDeployPage:true})
     }
     const handleBack = ()=>{
-        setStore({...Store, landingPageState2:false, landingPageState:false,
-             uploadPageState:false, uploadPageState2:false})
+        setStore({
+          ...Store, 
+          landingPageState2:false, 
+          landingPageState:false,
+          uploadPageState:false,
+          uploadPageState2:false, 
+          credentials: {}, 
+          clusters: null, 
+          clusterCount: 0,
+          gcploc: null
+        })
     }
     return(
         <div id='leSidebar'>

--- a/src/client/components/visualizer.tsx
+++ b/src/client/components/visualizer.tsx
@@ -9,8 +9,8 @@ const width = window.innerWidth;
 const height = window.innerHeight;
 const vizWidth = width;
 const fov = 100;
-const near = 50;
-const far = 5000;
+const near = 920;
+const far = 3000;
 
 
 // -----------fakeStore----------- if needed to test


### PR DESCRIPTION
Updated the amount you can zoom in the visualizer to prevent nodes from coming out of the cluster, also when clicking back on the sidebar, it clears the information from the store that otherwise would have allowed you back in even when entering no information. Last update was on the Upload page to change the placeholder to "Enter Project Info" being that it is the project information that goes to GCP and fetches any active clusters/nodes